### PR TITLE
Fix for #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,14 @@ const path = require('path');
 const resolve = require('resolve');
 const interpret = require('interpret');
 
+const EXTRE = /^[.]?[^.]+([.].*)$/;
+
 exports.registerFor = function (filepath, cwd) {
-  var ext = path.extname(filepath);
+  var match = EXTRE.exec(filepath);
+  if (!match) {
+    return;
+  }
+  var ext = match[1];
   if (Object.keys(require.extensions).indexOf(ext) !== -1) {
     return;
   }

--- a/test/fixtures/test.coffee.md
+++ b/test/fixtures/test.coffee.md
@@ -1,0 +1,10 @@
+Test Fixture
+============
+
+    module.exports =
+      data:
+        trueKey: true
+        falseKey: false
+        subKey:
+          subProp: 1
+

--- a/test/fixtures/test.iced.md
+++ b/test/fixtures/test.iced.md
@@ -1,0 +1,9 @@
+Test Fixture
+============
+
+    module.exports =
+      data:
+        trueKey: true
+        falseKey: false
+        subKey:
+          subProp: 1

--- a/test/fixtures/test.liticed
+++ b/test/fixtures/test.liticed
@@ -1,0 +1,8 @@
+# comment
+
+    module.exports =
+      data:
+        trueKey: true
+        falseKey: false
+        subKey:
+          subProp: 1

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,18 @@ describe('registerFor', function () {
     rechoir.registerFor('./test/fixtures/test.litcoffee');
     expect(require('./fixtures/test.litcoffee')).to.deep.equal(expected);
   });
+  it('should know literate coffee-script (.md)', function () {
+    rechoir.registerFor('./test/fixtures/test.coffee.md');
+    expect(require('./fixtures/test.coffee.md')).to.deep.equal(expected);
+  });
+  it('should know literate iced-coffee-script', function () {
+    rechoir.registerFor('./test/fixtures/test.liticed');
+    expect(require('./fixtures/test.liticed')).to.deep.equal(expected);
+  });
+  it('should know literate iced-coffee-script (.md)', function () {
+    rechoir.registerFor('./test/fixtures/test.iced.md');
+    expect(require('./fixtures/test.iced.md')).to.deep.equal(expected);
+  });
   it('should know toml', function () {
     rechoir.registerFor('./test/fixtures/test.toml');
     expect(require('./fixtures/test.toml')).to.deep.equal(expected);


### PR DESCRIPTION
- fixes #4: better extension recognition
added missing test cases for literate iced-coffee-script and the new .coffee.md/.iced.md extensions