### PR TITLE
Fix for #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ require('file.coffee');
 The underlying [interpret] module.
 
 [interpret]: https://github.com/tkellen/node-interpret
+
+
+## Adding Support for new Javascript Dialects and other DSLs
+
+Say you are currently developing your own Javascript dialect or a DSL, or simply want to integrate a DSL or dialect that is currently not being supported by [interpret](/tkellen/node-interpret), and you want to add support for these languages to your favorite tools right now.
+
+`rechoir` provides you with a mechanism for just doing that. Simply place a file called `node-interpret.js` in for example your package folder.
+
+The contents of that file are similar to what [interpret](/tkellen/node-interpret) exports. See the available test cases for more information.
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The underlying [interpret] module.
 
 [interpret]: https://github.com/tkellen/node-interpret
 
-
 ## Adding Support for new Javascript Dialects and other DSLs
 
 Say you are currently developing your own Javascript dialect or a DSL, or simply want to integrate a DSL or dialect that is currently not being supported by [interpret](/tkellen/node-interpret), and you want to add support for these languages to your favorite tools right now.
@@ -45,4 +44,3 @@ Say you are currently developing your own Javascript dialect or a DSL, or simply
 `rechoir` provides you with a mechanism for just doing that. Simply place a file called `node-interpret.js` in for example your package folder.
 
 The contents of that file are similar to what [interpret](/tkellen/node-interpret) exports. See the available test cases for more information.
-

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "node": ">= 0.10"
   },
   "scripts": {
-    "test": "mocha -R spec test/index.js"
+    "test": "mocha -R spec test/index.js test/**/index.js"
   },
   "dependencies": {
     "resolve": "^0.6.1",
-    "interpret": "^0.4.0"
+    "interpret": "^0.4.0",
+    "findup-sync": "^0.2.1"
   },
   "devDependencies": {
     "6to5": "^2.9.4",

--- a/test/custom-interpret/inherit/index.js
+++ b/test/custom-interpret/inherit/index.js
@@ -1,0 +1,34 @@
+const expect = require('chai').expect;
+const rechoir = require('../../../');
+
+var expected = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
+};
+
+describe('registerFor', function () {
+  it('should know foo', function () {
+    rechoir.registerFor('./test/custom-interpret/inherit/test.foo');
+    expect(require('./test.foo')).to.deep.equal(expected);
+  });
+});
+
+describe('interpret.extensions', function () {
+  it('should have ownProperty .foo:\'coffee-script/register\'', function () {
+    rechoir.registerFor('./test/custom-interpret/inherit/test.foo');
+    expect(rechoir.interpret.extensions).to.have.ownProperty('.foo', 'coffee-script/register');
+  });
+});
+
+afterEach(function (done) {
+  delete require.extensions['.foo'];
+  delete rechoir.interpret.extensions['.foo'];
+  delete rechoir.interpret.register['coffee-script/register'];
+  delete rechoir.interpret.jsVariants['.foo'];
+  done();
+});

--- a/test/custom-interpret/inherit/index.js
+++ b/test/custom-interpret/inherit/index.js
@@ -30,5 +30,6 @@ afterEach(function (done) {
   delete rechoir.interpret.extensions['.foo'];
   delete rechoir.interpret.register['coffee-script/register'];
   delete rechoir.interpret.jsVariants['.foo'];
+  delete rechoir.interpret.legacy['.foo'];
   done();
 });

--- a/test/custom-interpret/inherit/test.foo
+++ b/test/custom-interpret/inherit/test.foo
@@ -1,0 +1,7 @@
+module.exports = {
+  data: 
+    trueKey: true
+    falseKey: false
+    subKey:
+      subProp: 1
+}

--- a/test/custom-interpret/node-interpret.js
+++ b/test/custom-interpret/node-interpret.js
@@ -13,6 +13,9 @@ module.exports = {
   },
   jsVariants : {
     '.foo' : 'coffee-script/register'
+  },
+  legacy : {
+    '.foo' : 'coffee-script'
   }
 }
 

--- a/test/custom-interpret/node-interpret.js
+++ b/test/custom-interpret/node-interpret.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+  extensions : {
+    '.foo' : 'coffee-script/register' 
+  },
+  register : {
+    'coffee-script/register' : function (module) {
+      var compiler = require.extensions['.coffee'];
+      if (compiler && !require.extensions['.foo']) {
+        require.extensions['.foo'] = compiler;
+      }
+    }
+  },
+  jsVariants : {
+    '.foo' : 'coffee-script/register'
+  }
+}
+

--- a/test/custom-interpret/override/index.js
+++ b/test/custom-interpret/override/index.js
@@ -34,5 +34,6 @@ afterEach(function (done) {
   delete rechoir.interpret.extensions['.bar'];
   delete rechoir.interpret.register['coffee-script/register'];
   delete rechoir.interpret.jsVariants['.bar'];
+  delete rechoir.interpret.legacy['.bar'];
   done();
 });

--- a/test/custom-interpret/override/index.js
+++ b/test/custom-interpret/override/index.js
@@ -1,0 +1,38 @@
+const expect = require('chai').expect;
+const rechoir = require('../../../');
+
+var expected = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
+};
+
+describe('registerFor', function () {
+  it('should know bar', function () {
+    rechoir.registerFor('./test/custom-interpret/override/test.bar');
+    expect(require('./test.bar')).to.deep.equal(expected);
+  });
+});
+
+describe('interpret', function () {
+  it('should have ownProperty .bar:\'coffee-script/register\'', function () {
+    rechoir.registerFor('./test/custom-interpret/override/test.bar');
+    expect(rechoir.interpret.extensions).to.have.ownProperty('.bar', 'coffee-script/register');
+  });
+  it('should not have ownProperty .foo', function () {
+    rechoir.registerFor('./test/custom-interpret/override/test.bar');
+    expect(rechoir.interpret.extensions).to.not.have.ownProperty('.foo');
+  });
+});
+
+afterEach(function (done) {
+  delete require.extensions['.bar'];
+  delete rechoir.interpret.extensions['.bar'];
+  delete rechoir.interpret.register['coffee-script/register'];
+  delete rechoir.interpret.jsVariants['.bar'];
+  done();
+});

--- a/test/custom-interpret/override/node-interpret.js
+++ b/test/custom-interpret/override/node-interpret.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+  extensions : {
+    '.bar' : 'coffee-script/register' 
+  },
+  register : {
+    'coffee-script/register' : function (module) {
+      var compiler = require.extensions['.coffee'];
+      if (compiler && !require.extensions['.bar']) {
+        require.extensions['.bar'] = compiler;
+      }
+    }
+  },
+  jsVariants : {
+    '.bar' : 'coffee-script/register'
+  }
+}
+

--- a/test/custom-interpret/override/node-interpret.js
+++ b/test/custom-interpret/override/node-interpret.js
@@ -13,6 +13,9 @@ module.exports = {
   },
   jsVariants : {
     '.bar' : 'coffee-script/register'
+  },
+  legacy : {
+    '.bar' : 'coffee-script'
   }
 }
 

--- a/test/custom-interpret/override/test.bar
+++ b/test/custom-interpret/override/test.bar
@@ -1,0 +1,7 @@
+module.exports = {
+  data: 
+    trueKey: true
+    falseKey: false
+    subKey:
+      subProp: 1
+}


### PR DESCRIPTION
- fixes #6: custom node-interpret.js lets users add support for arbitrary languages/compilers/transpilers on-the-fly