### PR TITLE
Possible fix for #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Look for a module loader associated with the provided file and attempt require i
 
 #### Usage
 ```js
-var rechoir = require('rechoir');
+var rechoir = require('rechoir')(module);
 rechoir.registerFor('path/to/file.coffee');
 // coffee-script is now loaded and registered with node
 require('file.coffee');
@@ -40,7 +40,7 @@ The underlying [interpret] module.
 
 #### Usage
 ```js
-var rechoir = require('rechoir');
+var rechoir = require('rechoir')(module);
 rechoir.load('file.coffee');
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,31 +4,41 @@ const interpret = require('interpret');
 
 const EXTRE = /^[.]?[^.]+([.].*)$/;
 
-exports.registerFor = function (filepath, cwd) {
-  var match = EXTRE.exec(path.basename(filepath));
-  if (!match) {
-    return;
-  }
-  var ext = match[1];
-  if (Object.keys(require.extensions).indexOf(ext) !== -1) {
-    return;
-  }
-  if (!cwd) {
-    cwd = path.dirname(path.resolve(filepath));
-  }
-  var moduleName = interpret.extensions[ext];
-  if (moduleName) {
-    var compiler = require(resolve.sync(moduleName, {basedir: cwd}));
-    var register = interpret.register[moduleName];
-    if (register) {
-      register(compiler);
+module.exports = function (mod) {
+
+    var path = mod.require('path');
+
+    var result = {
+      registerFor : function (filepath, cwd) {
+        var match = EXTRE.exec(path.basename(filepath));
+        if (!match) {
+          return;
+        }
+        var ext = match[1];
+        if (Object.keys(require.extensions).indexOf(ext) !== -1) {
+          return;
+        }
+        if (!cwd) {
+          cwd = path.resolve(path.dirname(mod.filename));
+        }
+        var moduleName = interpret.extensions[ext];
+        if (moduleName) {
+          var compiler = mod.require(resolve.sync(moduleName, {basedir: cwd}));
+          var register = interpret.register[moduleName];
+          if (register) {
+            register(compiler);
+          }
+        }
+      },
+
+      load : function (filepath) {
+        result.registerFor(filepath);
+        return mod.require(filepath);
+      },
+
+      interpret : interpret
     }
-  }
+
+    return result;
 }
 
-exports.load = function (filepath) {
-  exports.registerFor(filepath);
-  return require(path.resolve(filepath));
-};
-
-exports.interpret = interpret;

--- a/index.js
+++ b/index.js
@@ -4,9 +4,19 @@ const interpret = require('interpret');
 
 const EXTRE = /^[.]?[^.]+([.].*)$/;
 
-module.exports = function (mod) {
+module.exports = function (aModule) {
 
-    var path = mod.require('path');
+    if (typeof aModule === 'undefined' || aModule === null) {
+      throw new Error('aModule parameter missing or null.');
+    }
+
+    if (typeof aModule.require !== 'function') {
+      throw new Error('aModule.require missing or not a function');
+    }
+
+    if (typeof aModule.filename !== 'string') {
+      throw new Error('aModule.filename missing or not a string');
+    }
 
     var result = {
       registerFor : function (filepath, cwd) {
@@ -19,11 +29,11 @@ module.exports = function (mod) {
           return;
         }
         if (!cwd) {
-          cwd = path.resolve(path.dirname(mod.filename));
+          cwd = path.resolve(path.dirname(aModule.filename));
         }
         var moduleName = interpret.extensions[ext];
         if (moduleName) {
-          var compiler = mod.require(resolve.sync(moduleName, {basedir: cwd}));
+          var compiler = aModule.require(resolve.sync(moduleName, {basedir: cwd}));
           var register = interpret.register[moduleName];
           if (register) {
             register(compiler);
@@ -33,7 +43,7 @@ module.exports = function (mod) {
 
       load : function (filepath) {
         result.registerFor(filepath);
-        return mod.require(filepath);
+        return aModule.require(filepath);
       },
 
       interpret : interpret

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const rechoir = require('../');
+const rechoir = require('../')(module);
 
 var expected = {
   data: {
@@ -13,23 +13,23 @@ var expected = {
 
 describe('registerFor', function () {
   it('should know coco', function () {
-    rechoir.registerFor('./test/fixtures/test.co');
+    rechoir.registerFor('./fixtures/test.co');
     expect(require('./fixtures/test.co')).to.deep.equal(expected);
   });
   it('should know coffee-script', function () {
-    rechoir.registerFor('./test/fixtures/test.coffee');
+    rechoir.registerFor('./fixtures/test.coffee');
     expect(require('./fixtures/test.coffee')).to.deep.equal(expected);
   });
   it('should know csv', function () {
-    rechoir.registerFor('./test/fixtures/test.csv');
+    rechoir.registerFor('./fixtures/test.csv');
     expect(require('./fixtures/test.csv')).to.deep.equal([['r1c1','r1c2'],['r2c1','r2c2']]);
   });
   it('should know iced-coffee-script', function () {
-    rechoir.registerFor('./test/fixtures/test.iced');
+    rechoir.registerFor('./fixtures/test.iced');
     expect(require('./fixtures/test.iced')).to.deep.equal(expected);
   });
   it('should know ini', function () {
-    rechoir.registerFor('./test/fixtures/test.ini');
+    rechoir.registerFor('./fixtures/test.ini');
     expect(require('./fixtures/test.ini')).to.deep.equal({
       data: {
         trueKey: "true",
@@ -38,51 +38,51 @@ describe('registerFor', function () {
     });
   });
   it('should know .js', function () {
-    rechoir.registerFor('./test/fixtures/test.js');
+    rechoir.registerFor('./fixtures/test.js');
     expect(require('./fixtures/test.js')).to.deep.equal(expected);
   });
   it('should know .json', function () {
-    rechoir.registerFor('./test/fixtures/test.json');
+    rechoir.registerFor('./fixtures/test.json');
     expect(require('./fixtures/test.json')).to.deep.equal(expected);
   });
   it('should know .json5', function () {
-    rechoir.registerFor('./test/fixtures/test.json5');
+    rechoir.registerFor('./fixtures/test.json5');
     expect(require('./fixtures/test.json5')).to.deep.equal(expected);
   });
   it('should know jsx', function () {
-    rechoir.registerFor('./test/fixtures/test.jsx');
+    rechoir.registerFor('./fixtures/test.jsx');
     expect(require('./fixtures/test.jsx')).to.deep.equal(expected);
   });
   it('should know livescript', function () {
-    rechoir.registerFor('./test/fixtures/test.ls');
+    rechoir.registerFor('./fixtures/test.ls');
     expect(require('./fixtures/test.ls')).to.deep.equal(expected);
   });
   it('should know literate coffee-script', function () {
-    rechoir.registerFor('./test/fixtures/test.litcoffee');
+    rechoir.registerFor('./fixtures/test.litcoffee');
     expect(require('./fixtures/test.litcoffee')).to.deep.equal(expected);
   });
   it('should know literate coffee-script (.md)', function () {
-    rechoir.registerFor('./test/fixtures/test.coffee.md');
+    rechoir.registerFor('./fixtures/test.coffee.md');
     expect(require('./fixtures/test.coffee.md')).to.deep.equal(expected);
   });
   it('should know literate iced-coffee-script', function () {
-    rechoir.registerFor('./test/fixtures/test.liticed');
+    rechoir.registerFor('./fixtures/test.liticed');
     expect(require('./fixtures/test.liticed')).to.deep.equal(expected);
   });
   it('should know literate iced-coffee-script (.md)', function () {
-    rechoir.registerFor('./test/fixtures/test.iced.md');
+    rechoir.registerFor('./fixtures/test.iced.md');
     expect(require('./fixtures/test.iced.md')).to.deep.equal(expected);
   });
   it('should know toml', function () {
-    rechoir.registerFor('./test/fixtures/test.toml');
+    rechoir.registerFor('./fixtures/test.toml');
     expect(require('./fixtures/test.toml')).to.deep.equal(expected);
   });
   it('should know xml', function () {
-    rechoir.registerFor('./test/fixtures/test.xml');
+    rechoir.registerFor('./fixtures/test.xml');
     expect(JSON.parse(require('./fixtures/test.xml'))).to.deep.equal(expected);
   });
   it('should know yaml', function () {
-    rechoir.registerFor('./test/fixtures/test.yaml');
+    rechoir.registerFor('./fixtures/test.yaml');
     expect(require('./fixtures/test.yaml')).to.deep.equal(expected);
   });
   it('must not fail on folders with dots', function () {
@@ -97,7 +97,7 @@ describe('registerFor', function () {
 describe('load', function () {
   it('should automatically register a loader and require', function () {
     delete require.extensions['.coffee'];
-    expect(rechoir.load('./test/fixtures/test.json')).to.deep.equal(expected);
+    expect(rechoir.load('./fixtures/test.json')).to.deep.equal(expected);
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -106,3 +106,37 @@ describe('interpret', function () {
     expect(rechoir.interpret).to.deep.equal(require('interpret'));
   });
 });
+
+describe('rechoir', function () {
+  it('should raise if module is undefined', function () {
+    expect(function() {
+      require('rechoir')();
+    }).to.throw(Error);
+  });
+  it('should raise if module is null', function () {
+    expect(function() {
+      require('rechoir')(null);
+    }).to.throw(Error);
+  });
+  it('should raise if module is missing require function', function () {
+    expect(function() {
+      require('rechoir')({});
+    }).to.throw(Error);
+  });
+  it('should raise if module.require is not a function', function () {
+    expect(function() {
+      require('rechoir')({require : {}});
+    }).to.throw(Error);
+  });
+  it('should raise if module.filepath is missing', function () {
+    expect(function() {
+      require('rechoir')({require : function(){}});
+    }).to.throw(Error);
+  });
+  it('should raise if module.filepath is not a string', function () {
+    expect(function() {
+      require('rechoir')({require : function(){}, filepath: {}});
+    }).to.throw(Error);
+  });
+});
+


### PR DESCRIPTION
- fixes #10: user must now pass in calling module, uses user module to require() modules/files

Have a look. I know that this will break the existing API. It will, however, make the behavior of load() similar to require() so that load() can be used as a drop-in replacement.

This might even go so far as to register the load function as the new require function in the user module, e.g.

```
var rechoir = require('rechoir')(module);
require = rechoir.load;

var sumfing = require('latest-stats.csv');
...
```

What do you think?