### PR TITLE
add support for legacy modules and dynamic config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+env:
+  - COFFEE=coffee-script@~1.3
+  - COFFEE=coffee-script@^1.7
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: 0.11
+before_script: npm install $COFFEE # install a specific version of coffee-script

--- a/index.js
+++ b/index.js
@@ -4,6 +4,24 @@ const interpret = require('interpret');
 
 const EXTRE = /^[.]?[^.]+([.].*)$/;
 
+function req (moduleName, cwd) {
+  return require(resolve.sync(moduleName, {basedir: cwd}));
+}
+
+function handleLegacy (moduleName, legacyModuleName, cwd) {
+  try {
+    return req(moduleName, cwd);
+  } catch (err) {
+    try {
+      return req(legacyModuleName, cwd);
+    } catch (__) {
+      // nice error messages
+      err.message = err.message.replace(moduleName, moduleName + '\' or \'' + legacyModuleName);
+      throw err;
+    }
+  }
+}
+
 exports.registerFor = function (filepath, cwd) {
   var match = EXTRE.exec(path.basename(filepath));
   if (!match) {
@@ -13,18 +31,26 @@ exports.registerFor = function (filepath, cwd) {
   if (Object.keys(require.extensions).indexOf(ext) !== -1) {
     return;
   }
+  var moduleName = interpret.extensions[ext];
+  if (!moduleName) {
+    return;
+  }
   if (!cwd) {
     cwd = path.dirname(path.resolve(filepath));
   }
-  var moduleName = interpret.extensions[ext];
-  if (moduleName) {
-    var compiler = require(resolve.sync(moduleName, {basedir: cwd}));
-    var register = interpret.register[moduleName];
-    if (register) {
-      register(compiler);
-    }
+  var legacyModuleName = interpret.legacy[ext];
+  var config = interpret.configurations[moduleName];
+  var compiler;
+  if (legacyModuleName) {
+    compiler = handleLegacy(moduleName, legacyModuleName, cwd);
+  } else {
+    compiler = req(moduleName, cwd);
   }
-}
+  var register = interpret.register[moduleName];
+  if (register) {
+    register(compiler, config);
+  }
+};
 
 exports.load = function (filepath) {
   exports.registerFor(filepath);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "resolve": "^0.6.1",
-    "interpret": "^0.3.0"
+    "interpret": "^0.4.0"
   },
   "devDependencies": {
     "LiveScript": "^1.2.0",


### PR DESCRIPTION
Relies on https://github.com/tkellen/node-interpret/pull/15

This is my POC for how the config objects would work.  It definitely needs to be cleaned up but all tests are passing and they even pass with coffee-script < 1.7 (will need to add tests for that).