### PR TITLE
Adding a test for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "require-ini": "0.0.1",
     "require-xml": "0.0.1",
     "require-yaml": "0.0.1",
-    "toml-require": "^1.0.1"
+    "toml-require": "^1.0.1",
+    "typescript-register": "^1.0.6"
   },
   "keywords": [
     "require",

--- a/test/fixtures/test.ts
+++ b/test/fixtures/test.ts
@@ -1,0 +1,11 @@
+var test = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
+};
+
+export = test;

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,10 @@ describe('registerFor', function () {
     rechoir.registerFor('./test/fixtures/test.iced.md');
     expect(require('./fixtures/test.iced.md')).to.deep.equal(expected);
   });
+  it('should know ts', function () {
+    rechoir.registerFor('./test/fixtures/test.ts');
+    expect(require('./fixtures/test.ts')).to.deep.equal(expected);
+  });
   it('should know toml', function () {
     rechoir.registerFor('./test/fixtures/test.toml');
     expect(require('./fixtures/test.toml')).to.deep.equal(expected);


### PR DESCRIPTION
This uses TypeScript register. Right now I'm using interpret from the
Github master since I need the latest version. This can be replaced when
the interpret version is bumped.